### PR TITLE
Update documentation to clarify staging repository role

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,14 +1,19 @@
-# Satoshi Station Deployment Guide
+# Satoshi Station Deployment Guide (STAGING REPOSITORY)
+
+> **IMPORTANT**: This is the documentation for the **staging repository** that deploys to **staging.sats.sv**. For the production repository that deploys to **sats.sv**, see [Satoshi-Learning-Path](https://github.com/Epic-Growth/Satoshi-Learning-Path).
 
 This document provides detailed information about the deployment architecture, CI/CD pipelines, and infrastructure setup for the Satoshi Station Learning Platform.
 
 ## Deployment Architecture
 
-Satoshi Station uses a modern cloud-native architecture:
+Satoshi Station uses a modern cloud-native architecture with separate repositories for staging and production:
 
-1. **Code Repositories**:
-   - Staging: `https://github.com/EpicGrowth/Satoshi-Learning-Next`
-   - Production: `https://github.com/Epic-Growth/Satoshi-Learning-Path`
+1. **Repository and Infrastructure Mapping**:
+
+   | Environment | Repository | Domain | Cloud Run Service |
+   |-------------|------------|--------|------------------|
+   | **Staging** | [Satoshi-Learning-Next](https://github.com/EpicGrowth/Satoshi-Learning-Next) (this repo) | staging.sats.sv | sats-web-staging |
+   | **Production** | [Satoshi-Learning-Path](https://github.com/Epic-Growth/Satoshi-Learning-Path) | sats.sv, www.sats.sv | sats-web |
 
 2. **CI/CD Pipeline**: GitHub Actions workflows for automated builds and deployments
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Satoshi Station Next
+# Satoshi Station Next (STAGING)
 
 Satoshi Station is a comprehensive learning platform for Bitcoin and Lightning Network education. This project is the Next.js migration and redesign of the original Satoshi Learning Path (sats.sv), built with modern web technologies and an improved user experience while maintaining the exact look and feel of the original site.
+
+> **IMPORTANT**: This is the **staging** repository that deploys to **staging.sats.sv**. For the production repository that deploys to **sats.sv**, see [Satoshi-Learning-Path](https://github.com/Epic-Growth/Satoshi-Learning-Path).
 
 ## Project Overview
 


### PR DESCRIPTION
This PR updates the documentation to clearly indicate this is the staging repository that deploys to staging.sats.sv and references the production repository.