### PR TITLE
Fix: Resolve error on opening mobile menu after module completion

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,15 +49,15 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <DarkModeEnhancer />
-          <EnhancedBackground />
-          <div className="relative flex min-h-screen flex-col">
-            <Header />
-            <LearningProgressProvider>
+          <LearningProgressProvider>
+            <DarkModeEnhancer />
+            <EnhancedBackground />
+            <div className="relative flex min-h-screen flex-col">
+              <Header />
               <main className="flex-1">{children}</main>
-            </LearningProgressProvider>
-            <Footer />
-          </div>
+              <Footer />
+            </div>
+          </LearningProgressProvider>
         </ThemeProvider>
       </body>
     </html>


### PR DESCRIPTION
Ensured LearningProgressProvider in `src/app/layout.tsx` wraps the Header, main content, and Footer. This makes the learning progress context available to learning sidebars when rendered within the main mobile navigation panel (part of the Header).

This corrects an error that occurred when:
1. You completed a learning section.
2. You then opened the main mobile hamburger menu.

The error was due to the learning sidebar (e.g., BitcoinSidebar) not finding the LearningProgressContext when rendered inside the mobile menu, as the Header was previously outside the relevant provider's scope.