### PR TITLE
Refactor: Revert mobile nav sidebar injection and add ErrorBoundary t…

### DIFF
--- a/src/app/learn/lightning/layout.tsx
+++ b/src/app/learn/lightning/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { LightningSidebar } from '@/components/learn/lightning/lightning-sidebar';
+import ErrorBoundary from '@/components/layout/ErrorBoundary'; // Added import
 // Removed: import { MobileNav } from '@/components/learn/shared/mobile-nav';
 
 export default function LightningLearningLayout({
@@ -20,7 +21,9 @@ export default function LightningLearningLayout({
 
         <main className="w-full pt-[3.5rem] lg:pt-0">
           <div className="mx-auto max-w-4xl space-y-8 px-4 py-6 lg:px-8 lg:py-8">
-            {children}
+            <ErrorBoundary fallbackMessage="There was an error loading the content for this Lightning learning page. Please try again or contact support if the issue persists.">
+              {children}
+            </ErrorBoundary>
           </div>
         </main>
       </div>

--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -6,9 +6,7 @@ import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Bitcoin, Zap, Shield, Menu, X, ExternalLink, Search, FileText, Home } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { BitcoinSidebar } from '@/components/learn/bitcoin/bitcoin-sidebar';
-import { LightningSidebar } from '@/components/learn/lightning/lightning-sidebar';
-import ErrorBoundary from '@/components/layout/ErrorBoundary';
+// Removed BitcoinSidebar, LightningSidebar, ErrorBoundary imports
 
 // Navigation structure
 const navigationItems = [
@@ -57,8 +55,7 @@ export function MobileNav() {
   const [openSection, setOpenSection] = useState<string | null>(null);
   const pathname = usePathname();
 
-  const isOnBitcoinPath = pathname.startsWith('/learn/bitcoin');
-  const isOnLightningPath = pathname.startsWith('/learn/lightning');
+  // Removed isOnBitcoinPath and isOnLightningPath
 
   // Close the mobile menu when navigating
   useEffect(() => {
@@ -248,26 +245,7 @@ export function MobileNav() {
                   );
                 })}
 
-                {/* CONDITIONAL LEARNING PATH SIDEBAR SECTION */}
-                {(isOnBitcoinPath || isOnLightningPath) && (
-                  <div className="mt-4 pt-4 border-t border-border/50">
-                    <h4 className="px-3 py-2 text-sm font-semibold text-muted-foreground tracking-wider">
-                      {isOnBitcoinPath ? 'BITCOIN MODULES' : 'LIGHTNING MODULES'}
-                    </h4>
-                    <div className="px-0"> {/* bitcoin-sidebar and lightning-sidebar have their own padding */}
-                      {isOnBitcoinPath && (
-                        <ErrorBoundary fallbackMessage="Error loading Bitcoin learning modules. Please try again.">
-                          <BitcoinSidebar />
-                        </ErrorBoundary>
-                      )}
-                      {isOnLightningPath && (
-                        <ErrorBoundary fallbackMessage="Error loading Lightning learning modules. Please try again.">
-                          <LightningSidebar />
-                        </ErrorBoundary>
-                      )}
-                    </div>
-                  </div>
-                )}
+                {/* CONDITIONAL LEARNING PATH SIDEBAR SECTION - REMOVED */}
               </nav>
               
               {/* Start Learning Button */}


### PR DESCRIPTION
…o Lightning layout

- I reverted `src/components/layout/mobile-nav.tsx` to remove the conditional rendering of Bitcoin/Lightning sidebars. This addresses UX concerns about internal scrolling in the main mobile menu.
- I added an ErrorBoundary around the children in `src/app/learn/lightning/layout.tsx`. This is to help diagnose page load errors specific to Lightning learning pages by catching errors in their content and displaying a fallback UI.