### PR TITLE
I've added an ErrorBoundary around the `LightningSidebar` component i…

### DIFF
--- a/src/app/learn/lightning/layout.tsx
+++ b/src/app/learn/lightning/layout.tsx
@@ -16,7 +16,9 @@ export default function LightningLearningLayout({
       <div className="flex-1 lg:grid lg:grid-cols-[300px_1fr] xl:grid-cols-[350px_1fr]">
         {/* This aside is the desktop sidebar, already correctly configured */}
         <aside className="fixed left-0 top-14 hidden h-[calc(100vh-3.5rem)] w-[300px] border-r lg:sticky lg:block xl:w-[350px]">
-          <LightningSidebar />
+          <ErrorBoundary fallbackMessage="Error displaying the Lightning navigation menu.">
+            <LightningSidebar />
+          </ErrorBoundary>
         </aside>
 
         <main className="w-full pt-[3.5rem] lg:pt-0">


### PR DESCRIPTION
…n `src/app/learn/lightning/layout.tsx`.

This will help us figure out if errors happening when Lightning learning pages first load are coming from the `LightningSidebar` component. This is in addition to an existing ErrorBoundary that's already around the main page content in that same layout file.