### PR TITLE
I've relocated the ErrorBoundary to `src/app/learn/layout.tsx`.

### DIFF
--- a/src/app/learn/layout.tsx
+++ b/src/app/learn/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { LearningProgressProvider } from '@/contexts/learning-progress-context';
+import ErrorBoundary from '@/components/layout/ErrorBoundary'; // Added import
 
 export default function LearnLayout({
   children,
@@ -9,9 +10,11 @@ export default function LearnLayout({
 }) {
   return (
     <LearningProgressProvider>
-      <div className="flex min-h-screen">
-        {children}
-      </div>
+      <ErrorBoundary fallbackMessage="A critical error occurred while trying to load this learning page. Please try refreshing or contact support.">
+        <div className="flex min-h-screen"> {/* This div is the main container for children */}
+          {children}
+        </div>
+      </ErrorBoundary>
     </LearningProgressProvider>
   );
 }

--- a/src/app/learn/lightning/layout.tsx
+++ b/src/app/learn/lightning/layout.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { LightningSidebar } from '@/components/learn/lightning/lightning-sidebar';
-import ErrorBoundary from '@/components/layout/ErrorBoundary'; // Added import
-// Removed: import { MobileNav } from '@/components/learn/shared/mobile-nav';
+// ErrorBoundary import removed
 
 export default function LightningLearningLayout({
   children,
@@ -10,22 +9,18 @@ export default function LightningLearningLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col"> 
       {/* The div that previously wrapped MobileNav has been removed */}
       
       <div className="flex-1 lg:grid lg:grid-cols-[300px_1fr] xl:grid-cols-[350px_1fr]">
         {/* This aside is the desktop sidebar, already correctly configured */}
         <aside className="fixed left-0 top-14 hidden h-[calc(100vh-3.5rem)] w-[300px] border-r lg:sticky lg:block xl:w-[350px]">
-          <ErrorBoundary fallbackMessage="Error displaying the Lightning navigation menu.">
-            <LightningSidebar />
-          </ErrorBoundary>
+          <LightningSidebar />
         </aside>
 
         <main className="w-full pt-[3.5rem] lg:pt-0">
           <div className="mx-auto max-w-4xl space-y-8 px-4 py-6 lg:px-8 lg:py-8">
-            <ErrorBoundary fallbackMessage="There was an error loading the content for this Lightning learning page. Please try again or contact support if the issue persists.">
-              {children}
-            </ErrorBoundary>
+            {children}
           </div>
         </main>
       </div>


### PR DESCRIPTION
Here's what that involved:
- I removed the more granular ErrorBoundaries from `src/app/learn/lightning/layout.tsx`.
- I added a higher-level ErrorBoundary in `src/app/learn/layout.tsx` to wrap its children. This component will now catch errors occurring anywhere within the `/learn/*` page structure.

This change should help better diagnose client-side rendering errors on learning path pages by providing a fallback UI if any component within the general learn section fails.