### PR TITLE
feat: Enhance Liquid learning path integration

### DIFF
--- a/src/app/learn/liquid/liquid-applications/page.tsx
+++ b/src/app/learn/liquid/liquid-applications/page.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/ui/card';
+import { ArrowRight } from 'lucide-react';
+
+const moduleDetails = {
+  title: 'Applications & Use Cases',
+  description: 'Real-world applications of Liquid',
+  sections: [
+    { id: 'token-issuance', title: 'Token Issuance' },
+    { id: 'exchanges', title: 'Exchange Integration' },
+    { id: 'defi', title: 'DeFi on Liquid' },
+    { id: 'security-tokens', title: 'Security Tokens' },
+  ]
+};
+const moduleId = 'liquid-applications';
+
+export default function LiquidApplicationsPage() {
+  return (
+    <div className="container py-8 px-4 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl mb-4">
+          {moduleDetails.title}
+        </h1>
+        <p className="text-lg text-muted-foreground sm:text-xl max-w-3xl">
+          {moduleDetails.description}
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {moduleDetails.sections.map((section) => (
+          <Card key={section.id} className="p-6 flex flex-col justify-between hover:shadow-lg transition-shadow duration-200">
+            <div>
+              <h2 className="text-xl font-semibold mb-2 text-foreground">{section.title}</h2>
+              {/* You can add section.description here if available and desired */}
+            </div>
+            <Link
+              href={`/learn/liquid/${moduleId}/${section.id}`}
+              className="mt-4 inline-flex items-center text-bitcoin-orange hover:underline group"
+            >
+              Go to section
+              <ArrowRight className="ml-2 h-4 w-4 transform group-hover:translate-x-1 transition-transform duration-200" />
+            </Link>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/learn/liquid/liquid-assets/page.tsx
+++ b/src/app/learn/liquid/liquid-assets/page.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/ui/card';
+import { ArrowRight } from 'lucide-react';
+
+const moduleDetails = {
+  title: 'Asset Management',
+  description: 'Working with assets on Liquid',
+  sections: [
+    { id: 'asset-types', title: 'Asset Types' },
+    { id: 'asset-registry', title: 'Asset Registry' },
+    { id: 'asset-security', title: 'Asset Security' },
+    { id: 'l-btc', title: 'L-BTC' },
+  ]
+};
+const moduleId = 'liquid-assets';
+
+export default function LiquidAssetsPage() {
+  return (
+    <div className="container py-8 px-4 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl mb-4">
+          {moduleDetails.title}
+        </h1>
+        <p className="text-lg text-muted-foreground sm:text-xl max-w-3xl">
+          {moduleDetails.description}
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {moduleDetails.sections.map((section) => (
+          <Card key={section.id} className="p-6 flex flex-col justify-between hover:shadow-lg transition-shadow duration-200">
+            <div>
+              <h2 className="text-xl font-semibold mb-2 text-foreground">{section.title}</h2>
+              {/* You can add section.description here if available and desired */}
+            </div>
+            <Link
+              href={`/learn/liquid/${moduleId}/${section.id}`}
+              className="mt-4 inline-flex items-center text-bitcoin-orange hover:underline group"
+            >
+              Go to section
+              <ArrowRight className="ml-2 h-4 w-4 transform group-hover:translate-x-1 transition-transform duration-200" />
+            </Link>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/learn/liquid/liquid-fundamentals/page.tsx
+++ b/src/app/learn/liquid/liquid-fundamentals/page.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/ui/card';
+import { ArrowRight } from 'lucide-react';
+
+const moduleDetails = {
+  title: 'Liquid Fundamentals',
+  description: 'Learn the core concepts of the Liquid Network',
+  sections: [
+    { id: 'what-is-liquid', title: 'What is Liquid?' },
+    { id: 'federated-sidechains', title: 'Federated Sidechains' },
+    { id: 'confidential-transactions', title: 'Confidential Transactions' },
+    { id: 'asset-issuance', title: 'Asset Issuance' },
+  ]
+};
+const moduleId = 'liquid-fundamentals';
+
+export default function LiquidFundamentalsPage() {
+  return (
+    <div className="container py-8 px-4 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl mb-4">
+          {moduleDetails.title}
+        </h1>
+        <p className="text-lg text-muted-foreground sm:text-xl max-w-3xl">
+          {moduleDetails.description}
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {moduleDetails.sections.map((section) => (
+          <Card key={section.id} className="p-6 flex flex-col justify-between hover:shadow-lg transition-shadow duration-200">
+            <div>
+              <h2 className="text-xl font-semibold mb-2 text-foreground">{section.title}</h2>
+              {/* You can add section.description here if available and desired */}
+            </div>
+            <Link
+              href={`/learn/liquid/${moduleId}/${section.id}`}
+              className="mt-4 inline-flex items-center text-bitcoin-orange hover:underline group"
+            >
+              Go to section
+              <ArrowRight className="ml-2 h-4 w-4 transform group-hover:translate-x-1 transition-transform duration-200" />
+            </Link>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/learn/liquid/liquid-technical/page.tsx
+++ b/src/app/learn/liquid/liquid-technical/page.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/ui/card';
+import { ArrowRight } from 'lucide-react';
+
+const moduleDetails = {
+  title: 'Technical Deep Dive',
+  description: 'Advanced technical concepts of Liquid',
+  sections: [
+    { id: 'peg-mechanics', title: 'Peg Mechanics' },
+    { id: 'federation-consensus', title: 'Federation Consensus' },
+    { id: 'script-extensions', title: 'Script Extensions' },
+    { id: 'liquid-security', title: 'Security Model' },
+  ]
+};
+const moduleId = 'liquid-technical';
+
+export default function LiquidTechnicalPage() {
+  return (
+    <div className="container py-8 px-4 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl mb-4">
+          {moduleDetails.title}
+        </h1>
+        <p className="text-lg text-muted-foreground sm:text-xl max-w-3xl">
+          {moduleDetails.description}
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {moduleDetails.sections.map((section) => (
+          <Card key={section.id} className="p-6 flex flex-col justify-between hover:shadow-lg transition-shadow duration-200">
+            <div>
+              <h2 className="text-xl font-semibold mb-2 text-foreground">{section.title}</h2>
+              {/* You can add section.description here if available and desired */}
+            </div>
+            <Link
+              href={`/learn/liquid/${moduleId}/${section.id}`}
+              className="mt-4 inline-flex items-center text-bitcoin-orange hover:underline group"
+            >
+              Go to section
+              <ArrowRight className="ml-2 h-4 w-4 transform group-hover:translate-x-1 transition-transform duration-200" />
+            </Link>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -18,6 +18,13 @@ const footerLinks = {
     { name: 'Node Setup', href: '/learn/lightning/lightning-node-operations/node-setup' },
     { name: 'Security', href: '/learn/lightning/lightning-security/node-security' },
   ],
+  liquidLearning: [
+    { name: 'What is Liquid?', href: '/learn/liquid/liquid-fundamentals/what-is-liquid' },
+    { name: 'Federated Sidechains', href: '/learn/liquid/liquid-fundamentals/federated-sidechains' },
+    { name: 'Confidential Txns', href: '/learn/liquid/liquid-fundamentals/confidential-transactions' },
+    { name: 'Asset Issuance', href: '/learn/liquid/liquid-fundamentals/asset-issuance' },
+    { name: 'L-BTC', href: '/learn/liquid/liquid-assets/l-btc' },
+  ],
   resources: [
     { name: 'Bitcoin Whitepaper', href: 'https://bitcoin.org/bitcoin.pdf', external: true },
     { name: 'Lightning Network', href: 'https://lightning.network/', external: true },
@@ -119,6 +126,23 @@ export function Footer() {
             </ul>
           </div>
           
+          {/* Liquid Learning Links */}
+          <div>
+            <h2 className="font-semibold text-base mb-4 text-foreground">Liquid Network</h2>
+            <ul className="space-y-3 text-sm">
+              {footerLinks.liquidLearning.map((link) => (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className="text-muted-foreground/90 hover:text-bitcoin-orange transition-colors inline-flex items-center"
+                  >
+                    {link.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
           {/* Resources Links */}
           <div>
             <h2 className="font-semibold text-base mb-4 text-foreground">Resources</h2>

--- a/src/components/learn/liquid/liquid-sidebar.tsx
+++ b/src/components/learn/liquid/liquid-sidebar.tsx
@@ -21,8 +21,6 @@ export function LiquidSidebar() {
       pathPrefix="liquid"
       onModuleSelect={handleModuleSelect}
       showDifficultyFilter={showDifficultyFilter}
-      accentColor="text-cyan-500"
-      hoverColor="hover:bg-cyan-100 dark:hover:bg-cyan-900/20"
     />
   );
 }

--- a/src/components/learn/shared/learning-sidebar.tsx
+++ b/src/components/learn/shared/learning-sidebar.tsx
@@ -14,7 +14,7 @@ import { LearningModule, Section } from '@/types/learning';
 
 interface LearningSidebarProps {
   modules: LearningModule[];
-  pathPrefix: 'bitcoin' | 'lightning';
+  pathPrefix: 'bitcoin' | 'lightning' | 'liquid';
   onModuleSelect?: (moduleId: string, sectionId: string) => void;
   showDifficultyFilter?: boolean;
 }
@@ -109,12 +109,16 @@ export function LearningSidebar({
     const isNextSection = nextIncomplete?.moduleId === module.id && nextIncomplete?.sectionId === section.id;
     
     // Determine theme colors using our standardized CSS variables
-    const activeColor = pathPrefix === 'bitcoin' 
-      ? 'text-[var(--primary-light)] bg-[var(--primary-light)]/5' 
-      : 'text-lightning-purple bg-lightning-purple/5';
-    const completedColor = pathPrefix === 'bitcoin' 
-      ? 'text-[var(--primary-light)]' 
-      : 'text-lightning-purple';
+    const activeColor = pathPrefix === 'bitcoin'
+      ? 'text-[var(--primary-light)] bg-[var(--primary-light)]/5'
+      : pathPrefix === 'lightning'
+      ? 'text-lightning-purple bg-lightning-purple/5'
+      : 'text-blue-500 bg-blue-500/5'; // Default for liquid
+    const completedColor = pathPrefix === 'bitcoin'
+      ? 'text-[var(--primary-light)]'
+      : pathPrefix === 'lightning'
+      ? 'text-lightning-purple'
+      : 'text-blue-500'; // Default for liquid
 
     return (
       <Link
@@ -231,13 +235,17 @@ export function LearningSidebar({
               const formattedProgress = `${Math.round(progressPercentage)}%`;
               
               // Different styling based on light/dark mode is handled by Tailwind's dark class
-              const backgroundColor = pathPrefix === 'bitcoin' 
-                ? 'bg-[var(--primary-light)]/5 dark:bg-[var(--primary-light)]/10' 
-                : 'bg-lightning-purple/5 dark:bg-lightning-purple/10';
+              const backgroundColor = pathPrefix === 'bitcoin'
+                ? 'bg-[var(--primary-light)]/5 dark:bg-[var(--primary-light)]/10'
+                : pathPrefix === 'lightning'
+                ? 'bg-lightning-purple/5 dark:bg-lightning-purple/10'
+                : 'bg-blue-500/5 dark:bg-blue-500/10'; // Default for liquid
                 
-              const progressBarColor = pathPrefix === 'bitcoin' 
-                ? 'bg-[var(--primary-light)]' 
-                : 'bg-lightning-purple';
+              const progressBarColor = pathPrefix === 'bitcoin'
+                ? 'bg-[var(--primary-light)]'
+                : pathPrefix === 'lightning'
+                ? 'bg-lightning-purple'
+                : 'bg-blue-500'; // Default for liquid
                 
               const badgeColor = getDifficultyColor(module.difficulty);
 
@@ -258,8 +266,10 @@ export function LearningSidebar({
                       <div className="flex items-center">
                         {pathPrefix === 'bitcoin' ? (
                           <span className="text-[var(--primary-light)] mr-2">₿</span>
-                        ) : (
+                        ) : pathPrefix === 'lightning' ? (
                           <span className="text-lightning-purple mr-2">⚡</span>
+                        ) : (
+                          <span className="text-blue-500 mr-2">💧</span> // Default icon for liquid
                         )}
                         <span className="font-medium">{module.title}</span>
                       </div>


### PR DESCRIPTION
This commit addresses several aspects of the Liquid learning path:

1.  **Footer Links:** Added a "Liquid Network" section to the site footer with links to key Liquid learning modules, consistent with Bitcoin and Lightning sections.
2.  **Content Pages:**
    - Verified the existence of all `page.tsx` files for Liquid module sections as defined in `learning-modules.ts`.
    - Created missing module overview pages for `liquid-fundamentals`, `liquid-technical`, `liquid-assets`, and `liquid-applications` to ensure proper navigation and content structure. These pages provide an introduction to each module and link to its sections.
3.  **Navigation and Sidebar:**
    - Reviewed and confirmed correct link generation for Liquid modules in the mobile navigation menu (`mobile-nav.tsx`).
    - Updated the shared `LearningSidebar` component (`learning-sidebar.tsx`) to explicitly handle the 'liquid' pathPrefix, including type updates and default visual styling for Liquid modules.
    - Simplified `LiquidSidebar` by removing unused color props, relying on the shared component's new handling.

These changes ensure that the Liquid learning path is correctly represented in site navigation, has the necessary content pages, and is visually consistent with other learning paths.