### PR TITLE
fix: Resolve runtime errors on Liquid learning pages

### DIFF
--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -45,16 +45,10 @@ const navigationItems = [
     items: generateLearningItems(lightningModules, 'lightning'),
   },
   {
-    title: 'Liquid Learning', // Reconstructed object
+    title: 'Liquid Learning',
     icon: Droplet,
     path: '/learn/liquid',
-    items: [
-      {
-        title: 'Test: What is Liquid? (Hardcoded)',
-        href: '/learn/liquid/liquid-fundamentals/what-is-liquid'
-      },
-      ...generateLearningItems(liquidModules, 'liquid')
-    ],
+    items: generateLearningItems(liquidModules, 'liquid'),
   },
   {
     title: 'Resources',

--- a/src/components/learn/shared/mobile-learning-sidebar.tsx
+++ b/src/components/learn/shared/mobile-learning-sidebar.tsx
@@ -15,7 +15,8 @@ import {
   X, 
   Menu,
   Bitcoin,
-  Zap
+  Zap,
+  Droplet // Added for Liquid
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useLearningProgress } from '@/contexts/learning-progress-context';
@@ -25,7 +26,7 @@ import { ResetProgressButton } from './reset-progress-button';
 
 interface MobileLearningSidebarProps {
   modules: LearningModule[];
-  pathPrefix: 'bitcoin' | 'lightning';
+  pathPrefix: 'bitcoin' | 'lightning' | 'liquid'; // Updated
   onModuleSelect?: (moduleId: string, sectionId: string) => void;
 }
 
@@ -133,12 +134,17 @@ export function MobileLearningSidebar({
     const isNextSection = nextIncomplete?.moduleId === module.id && nextIncomplete?.sectionId === section.id;
     
     // Determine theme colors using our standardized CSS variables
-    const activeColor = pathPrefix === 'bitcoin' 
-      ? 'text-[var(--primary-light)] bg-[var(--primary-light)]/5' 
-      : 'text-lightning-purple bg-lightning-purple/5';
-    const completedColor = pathPrefix === 'bitcoin' 
-      ? 'text-[var(--primary-light)]' 
-      : 'text-lightning-purple';
+    const activeColor = pathPrefix === 'bitcoin'
+      ? 'text-[var(--primary-light)] bg-[var(--primary-light)]/5'
+      : pathPrefix === 'lightning'
+      ? 'text-lightning-purple bg-lightning-purple/5'
+      : 'text-cyan-500 bg-cyan-500/5'; // Liquid active color
+
+    const completedColor = pathPrefix === 'bitcoin'
+      ? 'text-[var(--primary-light)]'
+      : pathPrefix === 'lightning'
+      ? 'text-lightning-purple'
+      : 'text-cyan-500'; // Liquid completed color
 
     // Ensure the path is valid
     const sectionPath = `/learn/${pathPrefix}/${module.id}/${section.id}`;
@@ -184,8 +190,14 @@ export function MobileLearningSidebar({
           <div className="flex items-center">
             <span className="text-xs text-muted-foreground mr-2">{progress}%</span>
             <div className="w-8 h-1.5 rounded-full bg-muted overflow-hidden">
-              <div 
-                className={`h-full ${pathPrefix === 'bitcoin' ? 'bg-[var(--primary-light)]' : 'bg-lightning-purple'}`}
+              <div
+                className={`h-full ${
+                  pathPrefix === 'bitcoin'
+                    ? 'bg-[var(--primary-light)]'
+                    : pathPrefix === 'lightning'
+                    ? 'bg-lightning-purple'
+                    : 'bg-cyan-500' // Liquid progress bar color
+                }`}
                 style={{ width: `${progress}%` }}
               />
             </div>
@@ -208,14 +220,20 @@ export function MobileLearningSidebar({
       onClick={() => setIsOpen(true)}
       className={cn(
         "fixed bottom-6 right-6 z-40 rounded-full shadow-lg p-3 lg:hidden",
-        pathPrefix === 'bitcoin' ? 'bg-[var(--primary-light)] hover:bg-[var(--primary-light)]/90' : 'bg-lightning-purple hover:bg-lightning-purple/90'
+        pathPrefix === 'bitcoin'
+          ? 'bg-[var(--primary-light)] hover:bg-[var(--primary-light)]/90'
+          : pathPrefix === 'lightning'
+          ? 'bg-lightning-purple hover:bg-lightning-purple/90'
+          : 'bg-cyan-500 hover:bg-cyan-500/90' // Liquid FAB background
       )}
       aria-label="Open learning path navigation"
     >
       {pathPrefix === 'bitcoin' ? (
         <Bitcoin className="h-6 w-6 text-white" />
-      ) : (
+      ) : pathPrefix === 'lightning' ? (
         <Zap className="h-6 w-6 text-white" />
+      ) : (
+        <Droplet className="h-6 w-6 text-white" /> // Liquid FAB icon
       )}
     </Button>
   );
@@ -250,11 +268,17 @@ export function MobileLearningSidebar({
                 <div className="flex items-center">
                   {pathPrefix === 'bitcoin' ? (
                     <Bitcoin className="h-5 w-5 text-[var(--primary-light)] mr-2" />
-                  ) : (
+                  ) : pathPrefix === 'lightning' ? (
                     <Zap className="h-5 w-5 text-lightning-purple mr-2" />
+                  ) : (
+                    <Droplet className="h-5 w-5 text-cyan-500 mr-2" /> // Liquid header icon
                   )}
                   <span className="font-bold text-base">
-                    {pathPrefix === 'bitcoin' ? 'Bitcoin Learning' : 'Lightning Learning'}
+                    {pathPrefix === 'bitcoin'
+                      ? 'Bitcoin Learning'
+                      : pathPrefix === 'lightning'
+                      ? 'Lightning Learning'
+                      : 'Liquid Learning'} {/* Liquid header title */}
                   </span>
                 </div>
                 <Button 
@@ -347,13 +371,17 @@ export function MobileLearningSidebar({
                     const formattedProgress = `${Math.round(progressPercentage)}%`;
                     
                     // Different styling based on light/dark mode is handled by Tailwind's dark class
-                    const backgroundColor = pathPrefix === 'bitcoin' 
-                      ? 'bg-[var(--primary-light)]/5 dark:bg-[var(--primary-light)]/10' 
-                      : 'bg-lightning-purple/5 dark:bg-lightning-purple/10';
+                    const backgroundColor = pathPrefix === 'bitcoin'
+                      ? 'bg-[var(--primary-light)]/5 dark:bg-[var(--primary-light)]/10'
+                      : pathPrefix === 'lightning'
+                      ? 'bg-lightning-purple/5 dark:bg-lightning-purple/10'
+                      : 'bg-cyan-500/5 dark:bg-cyan-500/10'; // Liquid module background
                       
-                    const progressBarColor = pathPrefix === 'bitcoin' 
-                      ? 'bg-[var(--primary-light)]' 
-                      : 'bg-lightning-purple';
+                    const progressBarColor = pathPrefix === 'bitcoin'
+                      ? 'bg-[var(--primary-light)]'
+                      : pathPrefix === 'lightning'
+                      ? 'bg-lightning-purple'
+                      : 'bg-cyan-500'; // Liquid module progress bar
                       
                     const badgeColor = getDifficultyColor(module.difficulty);
 
@@ -374,8 +402,10 @@ export function MobileLearningSidebar({
                             <div className="flex items-center">
                               {pathPrefix === 'bitcoin' ? (
                                 <span className="text-[var(--primary-light)] mr-2">₿</span>
-                              ) : (
+                              ) : pathPrefix === 'lightning' ? (
                                 <span className="text-lightning-purple mr-2">⚡</span>
+                              ) : (
+                                <Droplet className="h-4 w-4 text-cyan-500 mr-2" /> // Liquid module title icon
                               )}
                               <span className="font-medium">{module.title}</span>
                             </div>

--- a/src/components/learn/shared/mobile-progress-tracker.tsx
+++ b/src/components/learn/shared/mobile-progress-tracker.tsx
@@ -15,7 +15,8 @@ import {
   CircleCheck, 
   RefreshCw, 
   Bitcoin, 
-  Zap 
+  Zap,
+  Droplet // Added for Liquid
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/navigation';
@@ -23,7 +24,7 @@ import { Button } from '@/components/ui/button';
 
 interface MobileProgressTrackerProps {
   modules: LearningModule[];
-  pathPrefix: 'bitcoin' | 'lightning';
+  pathPrefix: 'bitcoin' | 'lightning' | 'liquid'; // Updated
 }
 
 export function MobileProgressTracker({ modules, pathPrefix }: MobileProgressTrackerProps) {
@@ -103,7 +104,11 @@ export function MobileProgressTracker({ modules, pathPrefix }: MobileProgressTra
           <div className="bg-card border border-border rounded-lg p-4 m-4 max-w-xs w-full">
             <h3 className="font-semibold mb-2">Reset Progress</h3>
             <p className="text-sm text-muted-foreground mb-4">
-              Are you sure you want to reset your {pathPrefix === 'bitcoin' ? 'Bitcoin' : 'Lightning'} learning progress? 
+              Are you sure you want to reset your {
+                pathPrefix === 'bitcoin' ? 'Bitcoin'
+                : pathPrefix === 'lightning' ? 'Lightning'
+                : 'Liquid' // Liquid reset text
+              } learning progress?
               This action cannot be undone.
             </p>
             <div className="flex justify-end gap-2">
@@ -134,8 +139,10 @@ export function MobileProgressTracker({ modules, pathPrefix }: MobileProgressTra
             <div className="relative h-8 w-8 rounded-full overflow-hidden border border-border/50 flex items-center justify-center bg-muted/20">
               {pathPrefix === 'bitcoin' ? (
                 <Bitcoin className="h-4 w-4 text-bitcoin-orange" />
-              ) : (
+              ) : pathPrefix === 'lightning' ? (
                 <Zap className="h-4 w-4 text-lightning-purple" />
+              ) : (
+                <Droplet className="h-4 w-4 text-cyan-500" /> // Liquid path icon
               )}
             </div>
             
@@ -147,7 +154,11 @@ export function MobileProgressTracker({ modules, pathPrefix }: MobileProgressTra
                   className="text-sm font-medium hover:underline flex items-center gap-1"
                   onClick={handlePathTitleClick}
                 >
-                  {pathPrefix === 'bitcoin' ? 'Bitcoin Learning Path' : 'Lightning Learning Path'}
+                  {pathPrefix === 'bitcoin'
+                    ? 'Bitcoin Learning Path'
+                    : pathPrefix === 'lightning'
+                    ? 'Lightning Learning Path'
+                    : 'Liquid Learning Path'} {/* Liquid path title */}
                 </a>
                 
                 {/* Reset button - separate from the toggle */}


### PR DESCRIPTION
This commit fixes a critical issue that caused all Liquid learning pages (under `/learn/liquid/`) to fail with a runtime error: "A critical error occurred while trying to load this learning page."

The root cause was identified in shared mobile layout components:
- `src/components/learn/shared/mobile-learning-sidebar.tsx`
- `src/components/learn/shared/mobile-progress-tracker.tsx`

These components, used by `src/app/learn/liquid/layout.tsx`, were not correctly handling `pathPrefix="liquid"`. Their prop types did not include 'liquid', and their internal logic lacked cases for Liquid-specific theming (icons, colors, text).

Changes made:
- Updated prop types in `MobileLearningSidebar` and `MobileProgressTracker` to accept `pathPrefix="liquid"`.
- Added conditional logic to these components to correctly display Liquid-specific icons (Droplet), text ("Liquid Learning"), and a cyan-based color theme, consistent with other UI elements for Liquid.
- Removed a diagnostic hardcoded link from `src/components/layout/mobile-nav.tsx`, as it was confirmed that link generation was not the issue.

With these changes, Liquid learning pages should now render correctly without runtime errors, and the mobile-specific UI elements within the learning path will display appropriately for Liquid content.