### PR TITLE
style: Refine FAB icon/background colors and diagnose menu transparency

### DIFF
--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -102,7 +102,7 @@ export function MobileNav() {
           />
           
           {/* Menu panel */}
-          <div className="fixed right-0 top-0 h-full w-4/5 max-w-sm bg-background p-6 shadow-xl">
+          <div className="fixed right-0 top-0 h-full w-4/5 max-w-sm bg-white dark:bg-slate-900 border-2 border-red-500 p-6 shadow-xl">
             <div className="flex items-center justify-between mb-8">
               <Link 
                 href="/"

--- a/src/components/learn/shared/mobile-learning-sidebar.tsx
+++ b/src/components/learn/shared/mobile-learning-sidebar.tsx
@@ -221,19 +221,19 @@ export function MobileLearningSidebar({
       className={cn(
         "fixed bottom-6 right-6 z-40 rounded-full shadow-lg p-3 lg:hidden",
         pathPrefix === 'bitcoin'
-          ? 'bg-bitcoin-orange hover:bg-bitcoin-orange/90' // Changed
+          ? 'bg-white hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 border border-gray-300 dark:border-gray-600'
           : pathPrefix === 'lightning'
-          ? 'bg-lightning-purple hover:bg-lightning-purple/90' // Assumed correct
-          : 'bg-cyan-500 hover:bg-cyan-500/90' // Known working
+          ? 'bg-white hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 border border-gray-300 dark:border-gray-600'
+          : 'bg-cyan-500 hover:bg-cyan-500/90' // Liquid - unchanged
       )}
       aria-label="Open learning path navigation"
     >
       {pathPrefix === 'bitcoin' ? (
-        <Bitcoin className="h-6 w-6 text-white" />
+        <Bitcoin className="h-6 w-6 text-bitcoin-orange" /> // Icon color changed
       ) : pathPrefix === 'lightning' ? (
-        <Zap className="h-6 w-6 text-white" />
+        <Zap className="h-6 w-6 text-yellow-400" /> // Icon color changed
       ) : (
-        <Droplet className="h-6 w-6 text-white" /> // Liquid FAB icon
+        <Droplet className="h-6 w-6 text-white" /> // Liquid - unchanged
       )}
     </Button>
   );


### PR DESCRIPTION
This commit implements several styling updates based on your feedback:

1.  **FAB Icon and Background Color Adjustments:**
    - In `src/components/learn/shared/mobile-learning-sidebar.tsx`: - Bitcoin FAB: Icon is now `text-bitcoin-orange` on a light/neutral background (`bg-white dark:bg-gray-800` with border). - Lightning FAB: Icon is now `text-yellow-400` on a light/neutral background (`bg-white dark:bg-gray-800` with border). - Liquid FAB: Remains a white icon on a `bg-cyan-500` background. This provides more distinct, themed icons for Bitcoin and Lightning FABs.

2.  **Global Mobile Menu Panel Transparency Diagnosis:**
    - In `src/components/layout/mobile-nav.tsx`: - The main slide-out menu panel's background has been temporarily changed from `bg-background` to explicit opaque colors (`bg-white dark:bg-slate-900`). - A diagnostic border (`border-2 border-red-500`) has also been added to this panel. This change is to help diagnose reports of the menu panel appearing transparent specifically on learning path pages. If the panel is now consistently opaque, it indicates the issue lies with how the original `bg-background` (and its underlying CSS variable) is resolved or styled in the context of those pages.