### PR TITLE
fix: Resolve mobile theme toggle visibility and interaction issues

### DIFF
--- a/src/components/theme/theme-toggle.tsx
+++ b/src/components/theme/theme-toggle.tsx
@@ -28,7 +28,7 @@ export function ThemeToggle() {
           <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="border-bitcoin-orange/20 bg-background/95 backdrop-blur-sm">
+      <DropdownMenuContent align="end" className="z-[51] border-bitcoin-orange/20 bg-background/95 backdrop-blur-sm">
         <DropdownMenuItem 
           onClick={() => setTheme("light")} 
           className="hover:bg-bitcoin-orange/5 cursor-pointer"


### PR DESCRIPTION
This commit addresses a problem where the dark mode/light mode theme toggle in the mobile header would not open correctly or would disappear. The issue was likely caused by a z-index conflict between the ThemeToggle's DropdownMenuContent and other mobile header elements (such as the main MobileNav panel or its backdrop), which all might have been using a z-index of 50.

The `ThemeToggle` component (`src/components/theme/theme-toggle.tsx`) has been updated to apply a higher z-index (`z-[51]`) to its `DropdownMenuContent`. This ensures that the theme selection dropdown appears reliably above other elements in the mobile header, allowing it to be opened and interacted with as expected.